### PR TITLE
fix(代码): 修复diff代码块中，cm-error会导致显示红框的问题

### DIFF
--- a/onelight/style/code.css
+++ b/onelight/style/code.css
@@ -67,6 +67,12 @@ pre[lang=sequence] {
     color: #333
 }
 
+pre[lang="diff"] .cm-s-inner .cm-error {
+    border: none !important;
+    color: inherit !important;
+    background-color: transparent !important;
+}
+
 /* ---------------->> 代码块 <<---------------- */
 .md-fences,
 code {

--- a/onelight/style/code.css
+++ b/onelight/style/code.css
@@ -68,9 +68,9 @@ pre[lang=sequence] {
 }
 
 pre[lang="diff"] .cm-s-inner .cm-error {
-    border: none !important;
-    color: inherit !important;
-    background-color: transparent !important;
+    border: none;
+    color: inherit;
+    background-color: transparent;
 }
 
 /* ---------------->> 代码块 <<---------------- */

--- a/onelight/style/code.css
+++ b/onelight/style/code.css
@@ -67,7 +67,7 @@ pre[lang=sequence] {
     color: #333
 }
 
-pre[lang="diff"] .cm-s-inner .cm-error {
+pre[lang=diff] .cm-s-inner .cm-error {
     border: none;
     color: inherit;
     background-color: transparent;


### PR DESCRIPTION
git format-patch生成的文件中，会包含一些只有一个空格的空白行。如果把这个复制到diff代码框中，会有一个红框显示出来
<img width="710" height="758" alt="image" src="https://github.com/user-attachments/assets/0c06b48f-4109-4d20-86d4-301485c475ba" />
检查发现，是触发了cm-error。在code.css里添加了对应的配置之后，红框消失
<img width="854" height="1037" alt="image" src="https://github.com/user-attachments/assets/79acffe6-d481-4b5d-ae50-0c31ac459d83" />
