### PR TITLE
✨ feat: 添加段落和标题聚焦样式，提升编辑体验

### DIFF
--- a/onelight.css
+++ b/onelight.css
@@ -104,6 +104,24 @@
     margin-top: 3px;
 }
 
+/* 段落聚焦及标题聚焦 */
+/* 排除引用块内段落、目录项 */
+#write p.md-focus:not(blockquote p):not(.md-toc-content),
+#write h1.md-focus,
+#write h2.md-focus,
+#write h3.md-focus,
+#write h5.md-focus,
+#write h6.md-focus {
+    box-shadow: var(--box-shadow);
+    border-radius: var(--radius-xsmall);
+    background: var(--theme-light-color);
+}
+
+/* h4 聚焦只加阴影 */
+#write h4.md-focus {
+    box-shadow: var(--box-shadow);
+}
+
 #write p:not(:has(.md-image)) {
     transition: background-color 0.3s ease, box-shadow 0.3s ease, border-radius 0.3s ease;
 }

--- a/onelight.css
+++ b/onelight.css
@@ -105,8 +105,8 @@
 }
 
 /* 段落聚焦及标题聚焦 */
-/* 排除引用块内段落、目录项 */
-#write p.md-focus:not(blockquote p):not(.md-toc-content),
+/* 排除目录项 */
+#write p.md-focus:not(.md-toc-content),
 #write h1.md-focus,
 #write h2.md-focus,
 #write h3.md-focus,


### PR DESCRIPTION
###  此 PR 解决的问题

当使用暗色模式时可能会遇到下图的情况，右下角的图片的颜色与字体颜色混合在一起导致难以辨认文字内容，在此 PR 中我使用了聚焦样式解决了这个问题

##### 应用前：

<img width="1857" height="178" alt="Snipaste_2026-06-12_11-12-32" src="https://github.com/user-attachments/assets/899acf8b-f5d1-4f76-8f0b-634e6ae68a67" />


##### 应用后：

<img width="1905" height="178" alt="Snipaste_2026-06-12_11-56-43" src="https://github.com/user-attachments/assets/303049ee-78dc-4a9e-854d-0afe329e21e3" />



###  变更内容

- **段落聚焦样式**: 为段落添加聚焦状态，显示默认背景 + 阴影 + 圆角
- **标题聚焦样式**: 为标题添加聚焦状态
  - h1-h3, h5-h6: 背景 + 阴影 + 圆角
  - h4: 仅阴影（保留原有背景块）
- **排除项**: 引用块内段落、目录项不应用聚焦样式（也是为了防止与原有样式冲突）

###  效果

- 当光标聚焦在当前段落或标题时会显示聚焦状态，从而使文字显示更清晰